### PR TITLE
fix: 补充用户选择器构建依赖

### DIFF
--- a/src/frontend/devops-codecc/package.json
+++ b/src/frontend/devops-codecc/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@blueking/bk-user-display-name": "^1.0.2",
     "@blueking/bk-user-selector": "^0.1.1",
+    "@blueking/bkui-library": "^0.0.0-beta.6",
     "@blueking/log": "^2.0.14",
     "@blueking/login-modal": "^1.0.5",
     "aegis-web-sdk": "^1.24.18",


### PR DESCRIPTION
## 变更内容

- 在 CodeCC 前端依赖清单中补充 `@blueking/bkui-library@^0.0.0-beta.6`。

## 问题原因

`@blueking/bk-user-selector/vue2` 的构建产物直接引用了 `@blueking/bkui-library`，但项目未显式声明该依赖，导致执行 `npm run build` 时出现模块解析失败。

## 影响

- 恢复 CodeCC 前端生产构建。
- 不涉及业务逻辑或页面行为调整。

## 验证

- `npm run build`：通过。
- Webpack 仅保留原有包体积告警，无构建错误。

## 关联

- TAPD：`136219436`
